### PR TITLE
Add support for newer versions of Mongoose (5.x.y)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
   "devDependencies": {
     "mocha": "2.x.x",
     "should": "8.2.2",
-    "mongoose": "~> 4.x"
+    "mongoose": ">=4.x <=5.x"
   },
   "peerDependencies": {
-    "mongoose": "~> 4.x"
+    "mongoose": ">=4.x <=5.x"
   }
 }


### PR DESCRIPTION
`mongoose-float` works fine with the latest versions of Mongoose, but that wasn't reflected in the module's dependencies. This caused npm to complain about missing peer dependencies when installing mongoose-flat with newer versions of Mongoose.

Now any Mongoose version between v4 and v5 is supported.