### PR TITLE
CastError update

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,13 +6,14 @@ var CastError = mongoose.SchemaType.CastError;
 
 function FloatType(digits) {
 	function Float(path, options) {
+		this.path = path;
 		mongoose.SchemaTypes.Number.call(this, path, options);
 	}
 
 	util.inherits(Float, mongoose.SchemaTypes.Number);
 
 	Float.prototype.cast = function(value) {
-		if (typeof value !== 'number') return new CastError('The value you passed should be number');
+		if (typeof value !== 'number') return new CastError('Number', value, this.path);
 
 		return Number(value.toFixed(digits || 2));
 	};


### PR DESCRIPTION
When saving incorrect types to Float, CastError returns "CastError: Cast to **The value you passed should be number** failed for value **undefined** at path **undefined**"

By changing the message to "Number" and passing **value** and **path** to CastError constructor, error now returns "CastError: Cast to Number failed for value _value_ at path _path_"