### PR TITLE
Fix undefined type error on new mongoose instance

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,7 +24,7 @@ function FloatType(digits) {
 module.exports.loadType = function(mongoose, digits) {
 	var floatType = new FloatType(digits);
 
-	mongoose.SchemaTypes.Float = mongoose.Types.Float = floatType;
+	mongoose.Schema.Types.Float = mongoose.SchemaTypes.Float = mongoose.Types.Float = floatType;
 
 	return floatType;
 };

--- a/test/index.js
+++ b/test/index.js
@@ -2,8 +2,9 @@ var should = require('should');
 var mongoose = require('mongoose');
 var lib = require('../lib/index.js');
 
+var new_instance = new mongoose.Mongoose();
 var Float = lib.loadType(mongoose);
-var UserSchema = mongoose.Schema({ balance: { type: Float } });
+var UserSchema = new mongoose.Schema({ balance: { type: Float } });
 var User = mongoose.model('User', UserSchema);
 
 describe('SchemaTypes Float', function () {
@@ -27,6 +28,21 @@ describe('SchemaTypes Float', function () {
 		});
 		it('mongoose.Schema.Types.Float should contain cast method', function () {
 			mongoose.Schema.Types.Float.prototype.cast.should.be.a.Function;
+		});
+	});
+
+	describe('new_instance.Schema.Types.Float', function () {
+		before(function () {
+			require('../lib/index.js').loadType(new_instance);
+		});
+		it('new_instance.Schema.Types should contain Float type property', function () {
+			new_instance.Schema.Types.should.have.ownProperty('Float');
+		});
+		it('new_instance.Schema.Types.Float should contain the constructor', function () {
+			new_instance.Schema.Types.Float.should.be.a.Function;
+		});
+		it('new_instance.Schema.Types.Float should contain cast method', function () {
+			new_instance.Schema.Types.Float.prototype.cast.should.be.a.Function;
 		});
 	});
 


### PR DESCRIPTION
Since mongoose 5.3.8, every instance's schema types are separate. So assigning the float type to the default instance doesn't work on others.