### PR TITLE
Implicit representation of check required implemented with tests

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,6 +18,8 @@ function FloatType(digits) {
 		return Number(value.toFixed(digits || 2));
 	};
 
+	Float._checkRequired = v => typeof v === 'number' || v instanceof Number;
+
 	return Float;
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -14,6 +14,12 @@ describe('SchemaTypes Float', function () {
 			module.should.have.ownProperty('loadType');
 			module.loadType.should.be.a.Function;
 		});
+
+		// it('should contain _checkRequired method', function () {
+		// 	var module = require('../lib/index.js');
+		// 	module.should.have.ownProperty('_checkRequired');
+		// 	module._checkRequired.should.be.a.Function;
+		// });
 	});
 
 	describe('mongoose.Schema.Types.Float', function () {
@@ -29,6 +35,9 @@ describe('SchemaTypes Float', function () {
 		it('mongoose.Schema.Types.Float should contain cast method', function () {
 			mongoose.Schema.Types.Float.prototype.cast.should.be.a.Function;
 		});
+		it('mongoose.Schema.Types.Float should contain _checkRequired method', function () {
+			mongoose.Schema.Types.Float._checkRequired.should.be.a.Function;
+		});
 	});
 
 	describe('newInstance.Schema.Types.Float', function () {
@@ -43,6 +52,9 @@ describe('SchemaTypes Float', function () {
 		});
 		it('newInstance.Schema.Types.Float should contain cast method', function () {
 			newInstance.Schema.Types.Float.prototype.cast.should.be.a.Function;
+		});
+		it('newInstance.Schema.Types.Float should contain _checkRequired method', function () {
+			newInstance.Schema.Types.Float._checkRequired.should.be.a.Function;
 		});
 	});
 


### PR DESCRIPTION
When the type are used with other attributes of schema an method called "_checkRequired" with a representation of implicit method. This may cause an unsolved condition on the usage like a "required", on that pull request, a solution proposed implements same check of Number type of mongoose.